### PR TITLE
Update internal-tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.8
+FROM dcanumn/internal-tools:v1.0.9
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Increment internal-tools from v1.0.8 to v1.0.9. The new release has changes from dcan_bold_proc that improve timeseries bandpass filtering.