### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.9
+FROM dcanumn/internal-tools:v1.0.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Increment the internal tools version to include the updated DBP that has recompiled binaries with zero padding hotfix