### PR TITLE
Downgrade MRE from v96 to v91

### DIFF
--- a/app/SetupEnv.sh
+++ b/app/SetupEnv.sh
@@ -38,12 +38,12 @@ export MSMBINDIR=/opt/msm/Ubuntu
 
 
 # Set up DCAN Environment Variables
-export MCRROOT=/opt/mcr/v96
+export MCRROOT=/opt/mcr/v91
 export DCANBOLDPROCDIR=/opt/dcan-tools/dcan_bold_proc
 export DCANBOLDPROCVER=DCANBOLDProc_v4.0.0
 export EXECSUMDIR=/opt/dcan-tools/executivesummary
 export CUSTOMCLEANDIR=/opt/dcan-tools/customclean
-export MATLAB_PREFDIR=/tmp/.matlab/R2017a
+export MATLAB_PREFDIR=/tmp/.matlab/R2016b
 export ABCDTASKPREPDIR=/opt/dcan-tools/ABCD_tfMRI
 
 # hacky solution for now...


### PR DESCRIPTION
New MRE version matches the Matlab version that dcan_bold_proc was compiled with.