### PR TITLE
Fixes to DBP outlier detection, external-software Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:R2019a-test
+FROM dcanumn/internal-tools:v1.0.12
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.11
+FROM dcanumn/internal-tools:R2019a-test
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/app/SetupEnv.sh
+++ b/app/SetupEnv.sh
@@ -38,12 +38,12 @@ export MSMBINDIR=/opt/msm/Ubuntu
 
 
 # Set up DCAN Environment Variables
-export MCRROOT=/opt/mcr/v91
+export MCRROOT=/opt/mcr/v96
 export DCANBOLDPROCDIR=/opt/dcan-tools/dcan_bold_proc
 export DCANBOLDPROCVER=DCANBOLDProc_v4.0.0
 export EXECSUMDIR=/opt/dcan-tools/executivesummary
 export CUSTOMCLEANDIR=/opt/dcan-tools/customclean
-export MATLAB_PREFDIR=/tmp/.matlab/R2016b
+export MATLAB_PREFDIR=/tmp/.matlab/R2019a
 export ABCDTASKPREPDIR=/opt/dcan-tools/ABCD_tfMRI
 
 # hacky solution for now...

--- a/app/run.py
+++ b/app/run.py
@@ -25,7 +25,7 @@ NeuroImage, 62:782-90, 2012
 [6] Avants, BB et al. The Insight ToolKit image registration framework. Front
 Neuroinform. 2014 Apr 28;8:44. doi: 10.3389/fninf.2014.00044. eCollection 2014.
 """
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 import argparse
 import os


### PR DESCRIPTION
Changes:

Bump internal-tools to v1.0.12; this fixes: 
- issue in DCANBOLDProcessing which caused outliers.mat files to not be generated, (this affected releases v0.1.3 through v0.1.5, all of which used Matlab R2016b)
- a broken link to the NeuroDocker ANTs install that is downloaded as part of the external-software Docker build 

