### PR TITLE
anat-only ExecutiveSummary

### DIFF
--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -256,6 +256,13 @@ class ParameterSettings(object):
             val = val[arg]
         return val
 
+    def set_anat_only(self, anat_only=False):
+        if anat_only:
+            # Assume there is no 'func' data...
+            self.unproc = None
+            # and no output from dcan-bold-proc.
+            self.summary_dir = None
+
     def set_study_template(self, study_template, study_template_brain):
         """
         set template for intermediate registration steps.

--- a/app/run.py
+++ b/app/run.py
@@ -289,6 +289,9 @@ def interface(bids_dir, output_dir, subject_list=None, collect=False, ncpus=1,
         summary = True
 
         session_spec = ParameterSettings(session, out_dir)
+        if not run_func:
+            anat_only = True
+            session_spec.set_anat_only(anat_only)
 
         # set session parameters
         if study_template is not None:


### PR DESCRIPTION
Addresses https://github.com/DCAN-Labs/abcd-hcp-pipeline/issues/122 .

If input is anat-only or if " --ignore func" is used, then update session spec accordingly for compatibility with ExecutiveSummary.


