### PR TITLE
Delete brainvis.wustl.edu directory

### DIFF
--- a/brainvis.wustl.edu/Caret7.conf
+++ b/brainvis.wustl.edu/Caret7.conf
@@ -1,5 +1,0 @@
-[General]
-loggingLevel=INFO
-volumeAxesCrosshairs=false
-volumeAxesLabels=false
-


### PR DESCRIPTION
Resolves #134. (This directory is redundant because Caret / Workbench setup is done in the external-software stage of the container build now.)